### PR TITLE
Minor functionality improvements for tutorialAcceptTapsOnHighlightsOnly()

### DIFF
--- a/TNTutorialManager/TNTutorialManager.m
+++ b/TNTutorialManager/TNTutorialManager.m
@@ -470,7 +470,7 @@
 			viewsToHighlight = [self.delegate tutorialViewsToHighlight:[self currentIndex]];
 			CGPoint tapLocation = [sender locationInView:sender.view];
 			BOOL shouldAcceptTaps = NO;
-			if (acceptTapsOnHighlightsOnly && viewsToHighlight && viewsToHighlight.count) {
+			if (acceptTapsOnHighlightsOnly && viewsToHighlight && [viewsToHighlight count] > 0) {
 				for (UIView *view in viewsToHighlight) {
 					CGRect frame = [[self tutorialContainer] convertRect:[view frame] fromView:view.superview];
 					if (CGRectContainsPoint(frame, tapLocation)) {

--- a/TNTutorialManager/TNTutorialManager.m
+++ b/TNTutorialManager/TNTutorialManager.m
@@ -466,10 +466,11 @@
 	if (sender && [self.delegate respondsToSelector:@selector(tutorialAcceptTapsOnHighlightsOnly:)]) {
 		NSArray <UIView *> *viewsToHighlight;
 		if ([self.delegate respondsToSelector:@selector(tutorialViewsToHighlight:)]) {
+			BOOL acceptTapsOnHighlightsOnly = [self.delegate tutorialAcceptTapsOnHighlightsOnly:[self currentIndex]];
 			viewsToHighlight = [self.delegate tutorialViewsToHighlight:[self currentIndex]];
 			CGPoint tapLocation = [sender locationInView:sender.view];
 			BOOL shouldAcceptTaps = NO;
-			if (viewsToHighlight && viewsToHighlight.count) {
+			if (acceptTapsOnHighlightsOnly && viewsToHighlight && viewsToHighlight.count) {
 				for (UIView *view in viewsToHighlight) {
 					CGRect frame = [[self tutorialContainer] convertRect:[view frame] fromView:view.superview];
 					if (CGRectContainsPoint(frame, tapLocation)) {

--- a/TNTutorialManager/TNTutorialManager.m
+++ b/TNTutorialManager/TNTutorialManager.m
@@ -469,7 +469,7 @@
 			viewsToHighlight = [self.delegate tutorialViewsToHighlight:[self currentIndex]];
 			CGPoint tapLocation = [sender locationInView:sender.view];
 			BOOL shouldAcceptTaps = NO;
-			if (viewsToHighlight) {
+			if (viewsToHighlight && viewsToHighlight.count) {
 				for (UIView *view in viewsToHighlight) {
 					CGRect frame = [[self tutorialContainer] convertRect:[view frame] fromView:view.superview];
 					if (CGRectContainsPoint(frame, tapLocation)) {


### PR DESCRIPTION
If the user passes in an empty array of `viewsToHighlight`, then it should be treated equally as if the user had passed in `nil`.